### PR TITLE
fix: rename deviceId to cameraId in rest.js

### DIFF
--- a/WebRTC_JavaScript/js/rest.js
+++ b/WebRTC_JavaScript/js/rest.js
@@ -14,7 +14,7 @@ async function start() {
 
 async function initiateWebRTCSession() {
     try {
-        let body = { deviceId: deviceId, resolution: "notInUse" };
+        let body = { cameraId: deviceId, resolution: "notInUse" };
 
         if (streamId)
             body.streamId = streamId;


### PR DESCRIPTION
With `deviceId` I keep getting error: Failed to initiate WebRTC session - Error: input: CameraId is invalid Guid.

It works when I rename it to `cameraId`